### PR TITLE
Enhance source codes

### DIFF
--- a/src/File/Size.php
+++ b/src/File/Size.php
@@ -87,7 +87,7 @@ class Size
      */
     public function inKiloBytes(int $decimal = 2): float
     {
-        return number_format($this->size / static::KB_MULTIPLY_VALUE, $decimal);
+        return (float)number_format($this->size / static::KB_MULTIPLY_VALUE, $decimal);
     }
 
     /**
@@ -110,7 +110,7 @@ class Size
      */
     public function inMegaBytes(int $decimal = 2): float
     {
-        return number_format($this->size / static::MB_MULTIPLY_VALUE, $decimal);
+        return (float)number_format($this->size / static::MB_MULTIPLY_VALUE, $decimal);
     }
 
     /**


### PR DESCRIPTION
# Changed log
- Add the filter lists to evaluate the code covers and tests.
- Add the `EOF` (end of file) for every PHP files.
- The `number_format` function should return `string` , not `float`.
To get the current float value with two decimals, it should add the casting float type for `number_format` function and keep the return type hint and return comment annotation be the `float`.