### PR TITLE
Add gd extension check for unit test development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "php": "^7.2",
         "ext-json": "*",
-        "ext-fileinfo": "*"
+        "ext-fileinfo": "*",
+        "ext-gd": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.0"


### PR DESCRIPTION
# Changed log
- The `IMG_*` consts depend on `GD` extension, and adding the GD extension check inside `required-dev` block in `composer.json` to check this extension installed during development installation.